### PR TITLE
Feature/#41 add image to markdown

### DIFF
--- a/src/components/common_part/MarkdownForm.tsx
+++ b/src/components/common_part/MarkdownForm.tsx
@@ -54,7 +54,7 @@ const MarkdownForm = (props: MarkdownFormProps): JSX.Element => {
     if (event.target.files != null && event.target.files[0] != null) {
       // FileをStorageに保存する
       const image = event.target.files[0];
-      const imageName = await postImage(image, "text");
+      const imageName = await postImage(image, "text", false);
 
       // 画像のURLを取得してマークダウンの末尾に追加
       const imageRef = ref(storage, imageName);

--- a/src/components/common_part/MarkdownForm.tsx
+++ b/src/components/common_part/MarkdownForm.tsx
@@ -5,22 +5,15 @@ import {
   Tab,
   TabPanels,
   TabPanel,
-  Text,
-  Textarea,
   Stack,
   HStack,
   Button,
   Icon,
-  FormControl,
-  FormHelperText,
 } from "@chakra-ui/react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import ChackUIRenderer from "chakra-ui-markdown-renderer";
 import { BsImage } from "react-icons/bs";
 import { AiFillGithub } from "react-icons/ai";
 
-import { MarkdownInput } from "../index";
+import { MarkdownInput, MarkdownPreview } from "../index";
 
 type MarkdownFormProps = {
   pageType: "post" | "product";
@@ -83,20 +76,7 @@ const MarkdownForm = (props: MarkdownFormProps): JSX.Element => (
           />
         </TabPanel>
         <TabPanel p="0" pt="4">
-          <Text
-            as={ReactMarkdown}
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            components={ChackUIRenderer()}
-            remarkPlugins={[remarkGfm]}
-            bg="#FCFCFC"
-            border="1px"
-            borderColor="gray.200"
-            rounded="md"
-            minH="72"
-            p="4"
-          >
-            {props.text}
-          </Text>
+          <MarkdownPreview text={props.text} />
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/src/components/common_part/MarkdownForm.tsx
+++ b/src/components/common_part/MarkdownForm.tsx
@@ -20,6 +20,8 @@ import ChackUIRenderer from "chakra-ui-markdown-renderer";
 import { BsImage } from "react-icons/bs";
 import { AiFillGithub } from "react-icons/ai";
 
+import { MarkdownInput } from "../index";
+
 type MarkdownFormProps = {
   pageType: "post" | "product";
   text: string;
@@ -74,22 +76,11 @@ const MarkdownForm = (props: MarkdownFormProps): JSX.Element => (
       </Stack>
       <TabPanels>
         <TabPanel p="0" pt="4">
-          <FormControl>
-            <Textarea
-              value={props.text}
-              onChange={props.handleText}
-              placeholder="マークダウン形式で入力"
-              bg="#FCFCFC"
-              shadow="inner"
-              minH="72"
-              p="4"
-            />
-            {props.validText && (
-              <FormHelperText color="red">
-                説明を入力してください。
-              </FormHelperText>
-            )}
-          </FormControl>
+          <MarkdownInput
+            text={props.text}
+            validText={props.validText}
+            handleText={props.handleText}
+          />
         </TabPanel>
         <TabPanel p="0" pt="4">
           <Text

--- a/src/components/common_part/MarkdownForm.tsx
+++ b/src/components/common_part/MarkdownForm.tsx
@@ -76,7 +76,7 @@ const MarkdownForm = (props: MarkdownFormProps): JSX.Element => (
           />
         </TabPanel>
         <TabPanel p="0" pt="4">
-          <MarkdownPreview text={props.text} />
+          <MarkdownPreview text={props.text} isFeedback={false} />
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/src/components/common_part/MarkdownForm.tsx
+++ b/src/components/common_part/MarkdownForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import {
   Tabs,
   TabList,
@@ -21,6 +21,7 @@ type MarkdownFormProps = {
   validText: boolean;
   handleText: React.ChangeEventHandler<HTMLTextAreaElement>;
   handlePost: React.MouseEventHandler<HTMLButtonElement>;
+  // setText: React.Dispatch<React.SetStateAction<string>>;
 };
 
 /**
@@ -31,78 +32,89 @@ type MarkdownFormProps = {
  * @param props.handlePost 投稿ボタンを押した際の処理をする関数
  * @returns Markdownのコンポーネント
  */
-const MarkdownForm = (props: MarkdownFormProps): JSX.Element => (
-  <Stack pb="8">
-    <Tabs variant="unstyled">
-      <Stack
-        flexDir={{ base: "column-reverse", sm: "row" }}
-        justify="space-between"
-      >
-        <TabList pt="2">
-          <Tab
-            rounded="full"
-            fontSize={{ base: "sm", md: "md" }}
-            _selected={{ color: "#FCFCFC", bg: "#99CED4" }}
-          >
-            マークダウン
-          </Tab>
-          <Tab
-            rounded="full"
-            fontSize={{ base: "sm", md: "md" }}
-            _selected={{ color: "#FCFCFC", bg: "#99CED4" }}
-          >
-            プレビュー
-          </Tab>
-        </TabList>
-        {props.pageType === "post" && (
-          <Button variant="outline" w="max-content">
-            <Icon
-              as={AiFillGithub}
-              h="10"
-              w="10"
-              pr="2"
+const MarkdownForm = (props: MarkdownFormProps): JSX.Element => {
+  const imageInputRef = useRef<HTMLInputElement>(null);
+
+  const onClickAddButton = () => {
+    if (imageInputRef.current != null) {
+      imageInputRef.current.click();
+      console.log("click! click!!");
+    }
+  };
+
+  return (
+    <Stack pb="8">
+      <Tabs variant="unstyled">
+        <Stack
+          flexDir={{ base: "column-reverse", sm: "row" }}
+          justify="space-between"
+        >
+          <TabList pt="2">
+            <Tab
+              rounded="full"
               fontSize={{ base: "sm", md: "md" }}
+              _selected={{ color: "#FCFCFC", bg: "#99CED4" }}
+            >
+              マークダウン
+            </Tab>
+            <Tab
+              rounded="full"
+              fontSize={{ base: "sm", md: "md" }}
+              _selected={{ color: "#FCFCFC", bg: "#99CED4" }}
+            >
+              プレビュー
+            </Tab>
+          </TabList>
+          {props.pageType === "post" && (
+            <Button variant="outline" w="max-content">
+              <Icon
+                as={AiFillGithub}
+                h="10"
+                w="10"
+                pr="2"
+                fontSize={{ base: "sm", md: "md" }}
+              />
+              GitHubから読み込む
+            </Button>
+          )}
+        </Stack>
+        <TabPanels>
+          <TabPanel p="0" pt="4">
+            <MarkdownInput
+              text={props.text}
+              validText={props.validText}
+              handleText={props.handleText}
             />
-            GitHubから読み込む
-          </Button>
-        )}
-      </Stack>
-      <TabPanels>
-        <TabPanel p="0" pt="4">
-          <MarkdownInput
-            text={props.text}
-            validText={props.validText}
-            handleText={props.handleText}
+          </TabPanel>
+          <TabPanel p="0" pt="4">
+            <MarkdownPreview text={props.text} isFeedback={false} />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+      <HStack justify="space-between">
+        {/* 下のinputの代わりの画像変更用ボタン */}
+        <Button
+          leftIcon={<BsImage />}
+          variant="ghost"
+          onClick={onClickAddButton}
+        >
+          {/* 上のButtonをクリックするとinputもクリックされる */}
+          <input
+            hidden
+            ref={imageInputRef}
+            type="file"
+            accept="image/*"
+            // onChange={}
           />
-        </TabPanel>
-        <TabPanel p="0" pt="4">
-          <MarkdownPreview text={props.text} isFeedback={false} />
-        </TabPanel>
-      </TabPanels>
-    </Tabs>
-    <HStack justify="space-between">
-      {/* 下のinputの代わりの画像変更用ボタン */}
-      <Button
-        leftIcon={<BsImage />}
-        variant="ghost"
-        // onClick={}
-      >
-        {/* 上のButtonをクリックするとinputもクリックされる */}
-        <input
-          hidden
-          // ref={}
-          type="file"
-          accept="image/*"
-          // onChange={}
-        />
-        画像を追加
-      </Button>
-      <Button variant="outline" onClick={props.handlePost}>
-        {props.pageType === "post" && "作品を投稿する"}
-        {props.pageType === "product" && "フィードバックを投稿する"}
-      </Button>
-    </HStack>
-  </Stack>
-);
+          画像を追加
+        </Button>
+        <Button variant="outline" onClick={props.handlePost}>
+          {props.pageType === "post" && "作品を投稿する"}
+          {props.pageType === "product" && "フィードバックを投稿する"}
+        </Button>
+      </HStack>
+    </Stack>
+  );
+};
 
 export default MarkdownForm;

--- a/src/components/common_part/MarkdownInput.tsx
+++ b/src/components/common_part/MarkdownInput.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { FormControl, Textarea, FormHelperText } from "@chakra-ui/react";
+
+type MarkdonwInputProps = {
+  text: string;
+  validText: boolean;
+  handleText: React.ChangeEventHandler<HTMLTextAreaElement>;
+};
+
+const MarkdownInput = (props: MarkdonwInputProps): JSX.Element => (
+  <FormControl>
+    <Textarea
+      value={props.text}
+      onChange={props.handleText}
+      placeholder="マークダウン形式で入力"
+      bg="#FCFCFC"
+      shadow="inner"
+      minH="72"
+      p="4"
+    />
+    {props.validText && (
+      <FormHelperText color="red">説明を入力してください。</FormHelperText>
+    )}
+  </FormControl>
+);
+
+export default MarkdownInput;

--- a/src/components/common_part/MarkdownPreview.tsx
+++ b/src/components/common_part/MarkdownPreview.tsx
@@ -6,23 +6,37 @@ import ChackUIRenderer from "chakra-ui-markdown-renderer";
 
 type MarkdonwPreviewProps = {
   text: string;
+  isFeedback: boolean;
 };
 
 const MarkdownPreview = (props: MarkdonwPreviewProps): JSX.Element => (
-  <Text
-    as={ReactMarkdown}
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    components={ChackUIRenderer()}
-    remarkPlugins={[remarkGfm]}
-    bg="#FCFCFC"
-    border="1px"
-    borderColor="gray.200"
-    rounded="md"
-    minH="72"
-    p="4"
-  >
-    {props.text}
-  </Text>
+  <>
+    {props.isFeedback ? (
+      <Text
+        as={ReactMarkdown}
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        components={ChackUIRenderer()}
+        remarkPlugins={[remarkGfm]}
+      >
+        {props.text}
+      </Text>
+    ) : (
+      <Text
+        as={ReactMarkdown}
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        components={ChackUIRenderer()}
+        remarkPlugins={[remarkGfm]}
+        bg="#FCFCFC"
+        border="1px"
+        borderColor="gray.200"
+        rounded="md"
+        minH="72"
+        p="4"
+      >
+        {props.text}
+      </Text>
+    )}
+  </>
 );
 
 export default MarkdownPreview;

--- a/src/components/common_part/MarkdownPreview.tsx
+++ b/src/components/common_part/MarkdownPreview.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Text } from "@chakra-ui/react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import ChackUIRenderer from "chakra-ui-markdown-renderer";
+
+type MarkdonwPreviewProps = {
+  text: string;
+};
+
+const MarkdownPreview = (props: MarkdonwPreviewProps): JSX.Element => (
+  <Text
+    as={ReactMarkdown}
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    components={ChackUIRenderer()}
+    remarkPlugins={[remarkGfm]}
+    bg="#FCFCFC"
+    border="1px"
+    borderColor="gray.200"
+    rounded="md"
+    minH="72"
+    p="4"
+  >
+    {props.text}
+  </Text>
+);
+
+export default MarkdownPreview;

--- a/src/components/common_part/postImage.ts
+++ b/src/components/common_part/postImage.ts
@@ -1,0 +1,44 @@
+import { v4 as uuidv4 } from "uuid";
+import loadImage from "blueimp-load-image";
+import {
+  getStorage,
+  ref,
+  uploadBytes,
+  StorageReference,
+} from "firebase/storage";
+
+import app from "../../base";
+
+const storage = getStorage(app);
+
+const postImage = async (file: File, dir: string): Promise<string> => {
+  // 新しいファイル名を生成
+  const fileName = `${dir}/${uuidv4()}.jpeg`;
+
+  // File -> canvas -> dataUrl に変換する
+  // アイコンの圧縮・クロップ処理をおこなう
+  const loadFile = await loadImage(file, {
+    maxHeight: 512,
+    maxWidth: 512,
+    crop: true,
+    canvas: true,
+  });
+
+  // blobに変換
+  const canvasFile = loadFile.image as HTMLCanvasElement;
+  const dataUrl = canvasFile.toDataURL("image/jpeg");
+  const bin = atob(dataUrl.split(",")[1]);
+  const buffer = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) {
+    buffer[i] = bin.charCodeAt(i);
+  }
+  const blob = new Blob([buffer.buffer], { type: "image/jpeg" });
+
+  // Storageに保存
+  const newFileRef = ref(storage, fileName);
+  await uploadBytes(newFileRef, blob);
+
+  return fileName;
+};
+
+export default postImage;

--- a/src/components/common_part/postImage.ts
+++ b/src/components/common_part/postImage.ts
@@ -1,28 +1,42 @@
 import { v4 as uuidv4 } from "uuid";
 import loadImage from "blueimp-load-image";
-import {
-  getStorage,
-  ref,
-  uploadBytes,
-  StorageReference,
-} from "firebase/storage";
+import { getStorage, ref, uploadBytes } from "firebase/storage";
 
 import app from "../../base";
 
 const storage = getStorage(app);
 
-const postImage = async (file: File, dir: string): Promise<string> => {
+/**
+ * 画像をjpegに変換してFirebase Storageに保存する関数
+ * @param file 保存する画像
+ * @param dir 保存したいディレクトリ名
+ * @param isCrop 画像のクロップの有無
+ * @returns 保存した画像のファイル名（ダウンロードURLではない）
+ */
+const postImage = async (
+  file: File,
+  dir: string,
+  isCrop: boolean
+): Promise<string> => {
   // 新しいファイル名を生成
   const fileName = `${dir}/${uuidv4()}.jpeg`;
 
   // File -> canvas -> dataUrl に変換する
   // アイコンの圧縮・クロップ処理をおこなう
-  const loadFile = await loadImage(file, {
-    maxHeight: 512,
-    maxWidth: 512,
-    crop: true,
-    canvas: true,
-  });
+  let loadFile: loadImage.LoadImageResult;
+  if (isCrop) {
+    loadFile = await loadImage(file, {
+      maxHeight: 512,
+      maxWidth: 512,
+      crop: true,
+      canvas: true,
+    });
+  } else {
+    loadFile = await loadImage(file, {
+      maxWidth: 1920,
+      canvas: true,
+    });
+  }
 
   // loadImageをblobに変換
   // canvas.toBlobはコールバック関数の中でのみblobを扱うため非同期になる

--- a/src/components/common_part/postImage.ts
+++ b/src/components/common_part/postImage.ts
@@ -24,7 +24,9 @@ const postImage = async (file: File, dir: string): Promise<string> => {
     canvas: true,
   });
 
-  // blobに変換
+  // loadImageをblobに変換
+  // canvas.toBlobはコールバック関数の中でのみblobを扱うため非同期になる
+  // toBlobの完了を待つ処理がthenやawaitで実装できなかったためbufferを使用する
   const canvasFile = loadFile.image as HTMLCanvasElement;
   const dataUrl = canvasFile.toDataURL("image/jpeg");
   const bin = atob(dataUrl.split(",")[1]);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,5 +14,6 @@ export { default as ProductIcon } from "./common_part/ProductIcon";
 export { default as TagIcon } from "./common_part/TagIcon";
 export { default as MarkdownForm } from "./common_part/MarkdownForm";
 export { default as MarkdownInput } from "./common_part/MarkdownInput";
+export { default as MarkdownPreview } from "./common_part/MarkdownPreview";
 export { default as DisplayProduct } from "./common_part/DisplayProduct";
 export { default as Like } from "./common_part/Like";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,5 +13,6 @@ export { default as GithubIcon } from "./common_part/GithubIcon";
 export { default as ProductIcon } from "./common_part/ProductIcon";
 export { default as TagIcon } from "./common_part/TagIcon";
 export { default as MarkdownForm } from "./common_part/MarkdownForm";
+export { default as MarkdownInput } from "./common_part/MarkdownInput";
 export { default as DisplayProduct } from "./common_part/DisplayProduct";
 export { default as Like } from "./common_part/Like";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,3 +17,4 @@ export { default as MarkdownInput } from "./common_part/MarkdownInput";
 export { default as MarkdownPreview } from "./common_part/MarkdownPreview";
 export { default as DisplayProduct } from "./common_part/DisplayProduct";
 export { default as Like } from "./common_part/Like";
+export { default as postImage } from "./common_part/postImage";

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -93,8 +93,9 @@ const Post = (): JSX.Element => {
         await deleteObject(oldIconRef);
       }
 
+      // FileをStorageに保存し、アイコン名とURLをstateにセット
       const icon = event.target.files[0];
-      const newIconName = await postImage(icon, "test");
+      const newIconName = await postImage(icon, "icon");
       const newIconRef = ref(storage, newIconName);
       const downloadUrl = await getDownloadURL(newIconRef);
       setIconName(newIconName);

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -24,7 +24,7 @@ import loadImage from "blueimp-load-image";
 import { useHistory, useLocation } from "react-router-dom";
 
 import app from "../../base";
-import { GithubIcon, ProductIcon, TagIcon, MarkdownForm } from "..";
+import { GithubIcon, ProductIcon, TagIcon, MarkdownForm, postImage } from "..";
 import {
   editProduct,
   fetchProduct,
@@ -86,49 +86,19 @@ const Post = (): JSX.Element => {
       setError("ファイルが選択されていません");
       setIconUrl("");
     } else {
-      // ファイルが選択されている場合、新しいファイル名を生成
       setError("");
-      const icon = event.target.files[0];
-      const newIconName = `icon/${uuidv4()}.jpg`;
-
       // ファイルを選択し直した時に既存のファイルをStorageから削除
       if (iconName !== "") {
         const oldIconRef = ref(storage, iconName);
         await deleteObject(oldIconRef);
       }
-      setIconName(newIconName);
 
-      // アイコンの圧縮・クロップ処理してcanvas形式に変換
-      const loadIcon = await loadImage(icon, {
-        maxHeight: 512,
-        maxWidth: 512,
-        crop: true,
-        canvas: true,
-      });
-      const canvasIcon = loadIcon.image as HTMLCanvasElement;
-
-      // canvasをBlobに変換してStorageに保存
+      const icon = event.target.files[0];
+      const newIconName = await postImage(icon, "test");
       const newIconRef = ref(storage, newIconName);
-      canvasIcon.toBlob(
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        async (blobIcon) => {
-          if (blobIcon == null) {
-            setError("アイコンの変換に失敗しました");
-          } else {
-            await uploadBytes(newIconRef, blobIcon)
-              .then(() => {
-                setError("");
-              })
-              .catch(() => {
-                setError(`アイコンのアップロードに失敗しました。`);
-              });
-            const downloadUrl = await getDownloadURL(newIconRef);
-            setIconUrl(downloadUrl);
-          }
-        },
-        "image/jpeg",
-        0.95
-      );
+      const downloadUrl = await getDownloadURL(newIconRef);
+      setIconName(newIconName);
+      setIconUrl(downloadUrl);
     }
   };
 

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -89,9 +89,7 @@ const Post = (): JSX.Element => {
       // ファイルが選択されている場合、新しいファイル名を生成
       setError("");
       const icon = event.target.files[0];
-      const newIconName = `icon/${uuidv4()}${icon.name.slice(
-        icon.name.lastIndexOf(".")
-      )}`;
+      const newIconName = `icon/${uuidv4()}.jpg`;
 
       // ファイルを選択し直した時に既存のファイルをStorageから削除
       if (iconName !== "") {

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -92,7 +92,7 @@ const Post = (): JSX.Element => {
 
       // FileをStorageに保存し、アイコン名とURLをstateにセット
       const icon = event.target.files[0];
-      const newIconName = await postImage(icon, "icon");
+      const newIconName = await postImage(icon, "icon", true);
       const newIconRef = ref(storage, newIconName);
       const downloadUrl = await getDownloadURL(newIconRef);
       setIconName(newIconName);

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -15,12 +15,9 @@ import { BsImage } from "react-icons/bs";
 import {
   getStorage,
   ref,
-  uploadBytes,
   getDownloadURL,
   deleteObject,
 } from "firebase/storage";
-import { v4 as uuidv4 } from "uuid";
-import loadImage from "blueimp-load-image";
 import { useHistory, useLocation } from "react-router-dom";
 
 import app from "../../base";
@@ -411,6 +408,7 @@ const Post = (): JSX.Element => {
         validText={validMainText}
         handleText={handleMainText}
         handlePost={handlePost}
+        setText={setMainText}
       />
     </Stack>
   );

--- a/src/components/product/Product.tsx
+++ b/src/components/product/Product.tsx
@@ -20,7 +20,13 @@ import {
   DocumentData,
 } from "firebase/firestore";
 
-import { TagIcon, LinkLike, MarkdownForm, EditDeleteButton } from "../index";
+import {
+  TagIcon,
+  LinkLike,
+  MarkdownForm,
+  EditDeleteButton,
+  MarkdownPreview,
+} from "../index";
 import {
   fetchProduct,
   fetchUserInfo,
@@ -311,20 +317,7 @@ const Product = (): JSX.Element => {
           isLike={isLike}
           handleClickLikeButton={handleClickLikeButton}
         />
-        <Text
-          as={ReactMarkdown}
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          components={ChackUIRenderer()}
-          remarkPlugins={[remarkGfm]}
-          bg="#FCFCFC"
-          border="1px"
-          borderColor="gray.200"
-          rounded="md"
-          minH="72"
-          p="4"
-        >
-          {mainText}
-        </Text>
+        <MarkdownPreview text={mainText} isFeedback />
         <LinkLike
           githubUrl={githubUrl}
           productUrl={productUrl}
@@ -357,14 +350,7 @@ const Product = (): JSX.Element => {
                     {/* {console.log(feedback.postDate)} */}
                   </Text>
                 </HStack>
-                <Text
-                  as={ReactMarkdown}
-                  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                  components={ChackUIRenderer()}
-                  remarkPlugins={[remarkGfm]}
-                >
-                  {feedback.feedbackText}
-                </Text>
+                <MarkdownPreview text={feedback.feedbackText} isFeedback />
               </Stack>
             </HStack>
           ))}

--- a/src/components/product/Product.tsx
+++ b/src/components/product/Product.tsx
@@ -362,6 +362,7 @@ const Product = (): JSX.Element => {
           validText={false}
           handleText={handleFeedbackText}
           handlePost={handlePost}
+          setText={setFeedbackText}
         />
       </Stack>
     </>


### PR DESCRIPTION
postとproductのマークダウン下部の画像を追加ボタンが動作するようになりましたー
- 画像を追加ボタンクリックで画像を選択
- 選択するとマークダウンの末尾に画像表示用の文章（マークダウン）が追加
- 画像は追加した時点でStorageに保存される
- いまのところ追加した画像をStorageから削除する方法はない