### PR TITLE
作品画面の内容修正

### DIFF
--- a/src/components/product/EditDeleteButton.tsx
+++ b/src/components/product/EditDeleteButton.tsx
@@ -29,10 +29,9 @@ const EditDeleteButton = (props: EditDeleteButtonType): JSX.Element => {
         justify="flex-end"
         zIndex="1"
         position="fixed"
-        top={{ base: "auto", sm: "20" }}
-        bottom={{ base: "10", sm: "auto" }}
+        top="20"
         right={{ base: "4", xl: window.outerWidth / 2 - 500 }}
-        align={{ base: "flex-end", sm: "flex-start" }}
+        align="flex-start"
       >
         <IconButton
           icon={<EditIcon w="6" h="6" />}

--- a/src/components/product/LinkLike.tsx
+++ b/src/components/product/LinkLike.tsx
@@ -1,5 +1,15 @@
 import React from "react";
-import { HStack, Link, Button, Icon } from "@chakra-ui/react";
+import {
+  HStack,
+  Link,
+  Button,
+  Icon,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverArrow,
+} from "@chakra-ui/react";
 import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
 import { GithubIcon, ProductIcon } from "..";
 
@@ -15,13 +25,39 @@ const LinkLike = (props: LinkLikeProps): JSX.Element => (
   <HStack justify="space-between">
     {/* Githubと作品のリンクを表示 */}
     <HStack>
-      <Link href={props.githubUrl} isExternal>
-        <GithubIcon />
-      </Link>
+      {props.githubUrl && (
+        <Popover trigger="hover">
+          <PopoverTrigger>
+            <Link href={props.githubUrl} isExternal>
+              <GithubIcon />
+            </Link>
+          </PopoverTrigger>
+          <PopoverContent>
+            <PopoverArrow />
+            <PopoverHeader>
+              <Link href={props.githubUrl} isExternal fontSize="sm">
+                {props.githubUrl}
+              </Link>
+            </PopoverHeader>
+          </PopoverContent>
+        </Popover>
+      )}
       {props.productUrl && (
-        <Link href={props.productUrl} isExternal>
-          <ProductIcon />
-        </Link>
+        <Popover trigger="hover">
+          <PopoverTrigger>
+            <Link href={props.productUrl} isExternal>
+              <ProductIcon />
+            </Link>
+          </PopoverTrigger>
+          <PopoverContent>
+            <PopoverArrow />
+            <PopoverHeader>
+              <Link href={props.productUrl} isExternal fontSize="sm">
+                {props.productUrl}
+              </Link>
+            </PopoverHeader>
+          </PopoverContent>
+        </Popover>
       )}
     </HStack>
     {/* いいねボタン表示 */}

--- a/src/components/product/Product.tsx
+++ b/src/components/product/Product.tsx
@@ -11,10 +11,6 @@ import {
 } from "@chakra-ui/react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import moment from "moment";
-// TODO: 警告の除去のため、恐らく使っていないが一応コメントアウトしている
-// import ReactMarkdown from "react-markdown";
-// import remarkGfm from "remark-gfm";
-// import ChackUIRenderer from "chakra-ui-markdown-renderer";
 import {
   QuerySnapshot,
   QueryDocumentSnapshot,

--- a/src/components/product/Product.tsx
+++ b/src/components/product/Product.tsx
@@ -294,9 +294,8 @@ const Product = (): JSX.Element => {
               <TagIcon pt={{ base: "0", md: "2" }} minW="80px" />
               <Wrap>
                 {tags.map((tag, i) => (
-                  <WrapItem>
+                  <WrapItem key={i.toString()}>
                     <Tag
-                      key={i.toString()}
                       rounded="full"
                       py="2"
                       px="4"

--- a/src/components/product/Product.tsx
+++ b/src/components/product/Product.tsx
@@ -320,13 +320,6 @@ const Product = (): JSX.Element => {
           handleClickLikeButton={handleClickLikeButton}
         />
         <MarkdownPreview text={mainText} isFeedback />
-        <LinkLike
-          githubUrl={githubUrl}
-          productUrl={productUrl}
-          sumLike={sumLike}
-          isLike={isLike}
-          handleClickLikeButton={handleClickLikeButton}
-        />
         <Divider pt="4" />
         <Heading size="md">フィードバック</Heading>
         {/* フィードバックの表示 */}

--- a/src/components/product/Product.tsx
+++ b/src/components/product/Product.tsx
@@ -8,6 +8,8 @@ import {
   Avatar,
   Tag,
   Divider,
+  Wrap,
+  WrapItem,
 } from "@chakra-ui/react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import moment from "moment";
@@ -290,20 +292,21 @@ const Product = (): JSX.Element => {
           {tags[0] !== "" && (
             <>
               <TagIcon pt={{ base: "0", md: "2" }} minW="80px" />
-              <HStack flexWrap="wrap">
+              <Wrap>
                 {tags.map((tag, i) => (
-                  <Tag
-                    key={i.toString()}
-                    rounded="full"
-                    p="2"
-                    pl="4"
-                    pr="4"
-                    fontSize={{ base: "xs", sm: "sm", md: "md" }}
-                  >
-                    {tag}
-                  </Tag>
+                  <WrapItem>
+                    <Tag
+                      key={i.toString()}
+                      rounded="full"
+                      py="2"
+                      px="4"
+                      fontSize={{ base: "xs", sm: "sm", md: "md" }}
+                    >
+                      {tag}
+                    </Tag>
+                  </WrapItem>
                 ))}
-              </HStack>
+              </Wrap>
             </>
           )}
         </Stack>

--- a/src/components/product/Product.tsx
+++ b/src/components/product/Product.tsx
@@ -287,21 +287,25 @@ const Product = (): JSX.Element => {
         </Stack>
         {/* タグ表示 */}
         <Stack flexDir={{ base: "column", md: "row" }} pl="2">
-          <TagIcon pt={{ base: "0", md: "2" }} minW="80px" />
-          <HStack flexWrap="wrap">
-            {tags.map((tag, i) => (
-              <Tag
-                key={i.toString()}
-                rounded="full"
-                p="2"
-                pl="4"
-                pr="4"
-                fontSize={{ base: "xs", sm: "sm", md: "md" }}
-              >
-                {tag}
-              </Tag>
-            ))}
-          </HStack>
+          {tags[0] !== "" && (
+            <>
+              <TagIcon pt={{ base: "0", md: "2" }} minW="80px" />
+              <HStack flexWrap="wrap">
+                {tags.map((tag, i) => (
+                  <Tag
+                    key={i.toString()}
+                    rounded="full"
+                    p="2"
+                    pl="4"
+                    pr="4"
+                    fontSize={{ base: "xs", sm: "sm", md: "md" }}
+                  >
+                    {tag}
+                  </Tag>
+                ))}
+              </HStack>
+            </>
+          )}
         </Stack>
         <Divider pt="4" />
         {/* リンク、いいね、本文を表示 */}


### PR DESCRIPTION
## 🔨 変更内容
- タグがない場合にタグを非表示
- タグが2行にわたる時に上下のmarginを追加
- Githubと作品のURLにホバーするとURL表示
- スマホ版の編集ボタン・削除ボタンの位置を下部から上部に変更

## 📸 スクリーンショット
![image](https://user-images.githubusercontent.com/54769623/152464083-3720f3c3-4db2-4e86-aebf-de1dbe22e1ca.png)


## ✅ 解決するイシュー
- close #61 

## 🤝 関連するイシュー
- #61 

## 💡 確認しているけど、別イシューで対応したい事項
- marginとmomentに関する警告削除したい