### PR TITLE
Hotfix/72 search param error

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  printWidth: 120,
+};

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -22,6 +22,7 @@ const Home = (): JSX.Element => {
   };
 
   useEffect(() => {
+    if (!location.state) return;
     if (location.state.paramSearchTags) {
       setSearchStatus("paramSearchTags");
       setTagList(location.state.paramSearchTags);


### PR DESCRIPTION
- 検索に関するパラメータがない場合の処理を追加
- ついでに1行あたりの文字数を120文字に制限

close #72 